### PR TITLE
Add render featured image shortcode

### DIFF
--- a/CONTRIBUTING-GAMES.md
+++ b/CONTRIBUTING-GAMES.md
@@ -50,6 +50,18 @@ that the following text is present and splitting that presentation from the deta
 <!--more-->
 ```
 
+It is always recommended to have an image that clearly shows how the game look when playing. To ease reusing the `featured_image` for this purpose, you can use the following Hugo's shortcode where you like the image to be presented:
+
+```markdown
+{{<render-featured-image>}}
+```
+
+If you instead wish to use a different image, place it on the game folder and use the standard markdown image syntax:
+
+```markdown
+![image description](./image-filename.jpg)
+```
+
 ## Boardgame characteristics
 
 Still part of the page content, there is a section that presents the game characteristics presented by the creators and players:

--- a/boardgame-bootstrap-example/index.md
+++ b/boardgame-bootstrap-example/index.md
@@ -10,7 +10,7 @@ jogá-lo também.
 
 <!--more-->
 
-![Boardgame name board setup](boardgame-name.jpg)
+{{<render-featured-image>}}
 
 Dá uma descrição mais detalhada do jogo, combinando detalhes da jogabilidade, características distintivas e
 similaridades com outros jogos

--- a/content/games/7summits/index.md
+++ b/content/games/7summits/index.md
@@ -9,7 +9,7 @@ O *7 Summits* é um jogo competitivo onde os jogadores, num papel de alpinistas,
 
 <!--more-->
 
-![7 Summits board setup](7-summits-featured.jpg)
+{{<render-featured-image>}}
 
 Os jogadores têm como objectivo escalar várias montanhas e conquistar o topo do maior número delas antes do final do jogo. Para isso podem seguir um caminho mais seguro (e lento) ou correr mais riscos e superar todos os outros. Riscos têm consequências e uma queda pode levar o jogador a ter de iniciar a escalada do 0.
 

--- a/content/games/above-and-below/index.md
+++ b/content/games/above-and-below/index.md
@@ -10,7 +10,7 @@ Durante esta construção, os habitantes descobrem uma vasta rede de túneis sub
 
 <!--more-->
 
-![Above and Below board setup](above-below-featured.jpg)
+{{<render-featured-image>}}
 
 Os jogadores têm como objectivo principal construir uma vasta aldeia, cheia de infraestruturas. Para tal precisam de recursos humanos, monetários e alimentares que podem ser encontrados, maioritariamente, ao explorar uma vasta rede de túneis desconhecidos. Esta exploração é alimentada por histórias pré-definidas que o jogador terá de viver e tomar decisões do que fazer em situações muito variadas, inspiradas em jogos RPG.
 

--- a/content/games/carcassonne/index.md
+++ b/content/games/carcassonne/index.md
@@ -10,7 +10,7 @@ O *Carcassonne* é um jogo de colocação de peças onde os jogadores constroem 
 
 <!--more-->
 
-![Carcassonne board setup](./carcassonne-featured.png)
+{{<render-featured-image>}}
 
 Cada jogador, no seu turno, coloca uma peça de terreno no tabuleiro em construção e pode decidir colocar um dos seus seguidores numa das características dessa peça (campo, estrada, cidade, etc.).
 

--- a/content/games/cascadia/index.md
+++ b/content/games/cascadia/index.md
@@ -10,7 +10,7 @@ O *Cascadia* é um jogo competitivo onde os jogadores constroem o melhor ecossis
 
 <!--more-->
 
-![Cascadia board setup](cascadia-featured.jpg)
+{{<render-featured-image>}}
 
 Cada jogador trabalha num puzzle composto por peças de diferentes ecossistemas (aquático, deserto, florestal), posteriormente populados por animais selvagens, procurando cumprir o maior número de objetivos e arrecadar o prémio de melhor habitat.
 

--- a/content/games/catan/index.md
+++ b/content/games/catan/index.md
@@ -10,7 +10,7 @@ duration: 75
 
 <!--more-->
 
-![Catan board setup](catan-featured.webp)
+{{<render-featured-image>}}
 
 O objetivo é ser o primeiro a alcançar 10 pontos de vitória, através de construções, desenvolvimento e comércio com outros jogadores. A cada jogada, os dados determinam que recursos são produzidos, incentivando negociações e adaptações constantes às jogadas dos adversários.
 

--- a/content/games/celtae/index.md
+++ b/content/games/celtae/index.md
@@ -9,7 +9,7 @@ O *Celtae* é um jogo competitivo onde os jogadores lideram uma tribo celta na s
 
 <!--more-->
 
-![Celtae board setup](celtae-featured.jpg)
+{{<render-featured-image>}}
 
 Os jogadores têm como objectivo escalar várias montanhas e conquistar o topo do maior número delas antes do final do jogo. Para isso podem seguir um caminho mais seguro (e lento) ou correr mais riscos e superar todos os outros. Riscos têm consequências e uma queda pode levar o jogador a ter de iniciar a escalada do 0.
 

--- a/content/games/coloretto/index.md
+++ b/content/games/coloretto/index.md
@@ -10,7 +10,7 @@ O *Coloretto* é um jogo competitivo onde os jogadores procuram construir grande
 
 <!--more-->
 
-![Coloretto board setup](coloretto-featured.jpg)
+{{<render-featured-image>}}
 
 Os jogadores têm como objectivo colecionar o maior número de cartas (camaleões) da mesma cor, e com isso acumular mais pontos rumo à vitória. No entanto, como muitas famílias não são capazes de coexistir pacificamente, os jogadores terão de procurar a melhor estratégia para reduzir a quantidade de cores diferentes colecionadas.
 

--- a/content/games/dark-tomb-ice-chasers/index.md
+++ b/content/games/dark-tomb-ice-chasers/index.md
@@ -10,7 +10,7 @@ O *Dark Tomb* é um jogo cooperativo onde os jogadores assumem um papel de explo
 
 <!--more-->
 
-![Dark Tomb board setup](ice-chasers-featured.jpg)
+{{<render-featured-image>}}
 
 Cada jogador assume uma personagem com características e ações específicas. Todos os jogadores trabalham em conjunto para explorar totalmente a caverna onde se depararam, sobrevivendo aos ataques dos seus habitantes nativos (monstros). Com um motor simplificado de RPGs como Dungeon & Dragons, os jogadores têm de selecionar bem as ações a fazer e recorrer ao famoso D20 para definir o seu sucesso.
 

--- a/content/games/everdell/index.md
+++ b/content/games/everdell/index.md
@@ -9,7 +9,7 @@ O *Everdell* é um jogo competitivo onde os jogadores procuram construir a comun
 
 <!--more-->
 
-![Everdell board setup](everdell-featured.jpg)
+{{<render-featured-image>}}
 
 Cada jogador utiliza trabalhadores da sua comunidade para produzir recursos e riquezas que são, posteriormente, usados para aumentar a infraestrutura e os membros da sua comunidade.
 

--- a/content/games/hitster/index.md
+++ b/content/games/hitster/index.md
@@ -11,7 +11,7 @@ O _Hitster_ é um jogo onde os jogadores devem ordernar músicas por ordem crono
 
 <!--more-->
 
-![Hitster cards and timeline](./hitster-featured.webp)
+{{<render-featured-image>}}
 
 Cada jogador, por ordem, retira uma carta do baralho. O DJ está encarregue de tocar um excerto da música dessa carta, enquanto que o jogador deve-a colocar na posição cronológica correta da sua linha temporal pessoal, baseando-se no ano de lançamento da música.
 

--- a/content/games/mysterium/index.md
+++ b/content/games/mysterium/index.md
@@ -12,7 +12,7 @@ O *Mysterium* é um jogo cooperativo onde um jogador assume o papel de um fantas
 
 Através de cartas de visão artisticamente deslumbrantes, o fantasma fornece pistas abstratas que os outros jogadores devem interpretar em conjunto para descobrir a verdade.
 
-![Mysterium board setup](./mysterium-featured.png)
+{{<render-featured-image>}}
 
 O fantasma comunica através de "cartas de visão" com os restantes jogadores com pistas abstratas. Já estes, os investigadores, devem interpretar estas pistas abstratas para identificar o suspeito, o local e a arma do crime.
 

--- a/content/games/pandemic/index.md
+++ b/content/games/pandemic/index.md
@@ -10,7 +10,7 @@ O *Pandemic* é um jogo cooperativo onde os jogadores assumem um papel fundament
 
 <!--more-->
 
-![Pandemic board setup](pandemic-featured.jpg)
+{{<render-featured-image>}}
 
 Cada jogador assume uma personagem, com funções específicas, e em conjunto terão de planear bem os passos para que consigam, para vários vírus: controlar a sua expansão mundial e recolher os recursos necessários para encontrar a sua cura.
 

--- a/content/games/the-mind/index.md
+++ b/content/games/the-mind/index.md
@@ -10,7 +10,7 @@ O *The Mind* é um jogo cooperativo onde os jogadores devem jogar cartas numerad
 
 <!--more-->
 
-![The Mind cards](./the-mind-featured.jpg)
+{{<render-featured-image>}}
 
 O conceito é simples: cada jogador recebe cartas numeradas de 1 a 100 e, em conjunto, devem jogá-las por ordem crescente numa pilha central. A particularidade? Não podem comunicar de forma alguma, isto exclui falar e gestos, devem confiar apenas no coração das cartas.
 

--- a/layouts/_shortcodes/render-featured-image.html
+++ b/layouts/_shortcodes/render-featured-image.html
@@ -1,0 +1,9 @@
+{{ with $.Page }}
+
+    {{ $featured_image := partials.Include "func/GetFeaturedImage.html" . }}
+
+    <img src="{{ $featured_image }}" width="100%"
+        {{- with .Title }} title="{{ . }}" alt="{{ . }}" {{ end -}}
+    >
+
+{{ end }}


### PR DESCRIPTION
This PR introduces a new shortcode for game pages that reuse the `featured_image` in the body of the page, avoiding duplication of the image declaration.